### PR TITLE
Suggest to install this bundle to require-dev section

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ will give you a good base for testing a Symfony bundle.
 Via Composer
 
 ``` bash
-$ composer require nyholm/symfony-bundle-test
+$ composer require --dev nyholm/symfony-bundle-test
 ```
 
 ## Write a test


### PR DESCRIPTION
Since this is a bundle for testing I think it makes sense to suggest to install it to Composer's `require-dev` section in docs