### PR TITLE
Allow to test configurations with closures

### DIFF
--- a/src/AppKernel.php
+++ b/src/AppKernel.php
@@ -126,7 +126,7 @@ class AppKernel extends Kernel
                 ],
             ]);
 
-            $this->configFiles = array_unique($this->configFiles);
+            $this->configFiles = array_unique($this->configFiles, SORT_REGULAR);
             foreach ($this->configFiles as $path) {
                 $loader->load($path);
             }

--- a/tests/Fixtures/ConfigurationBundle/ConfigurationBundle.php
+++ b/tests/Fixtures/ConfigurationBundle/ConfigurationBundle.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Nyholm\BundleTest\Tests\Fixtures\ConfigurationBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+final class ConfigurationBundle extends Bundle
+{
+}

--- a/tests/Fixtures/ConfigurationBundle/DependencyInjection/Configuration.php
+++ b/tests/Fixtures/ConfigurationBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Nyholm\BundleTest\Tests\Fixtures\ConfigurationBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+final class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $tree = new TreeBuilder('configuration');
+
+        if (method_exists($tree, 'getRootNode')) {
+            $root = $tree->getRootNode();
+        } else {
+            $root = $tree->root('configuration');
+        }
+
+        $root
+            ->children()
+                ->scalarNode('foo')->isRequired()->end()
+                ->arrayNode('bar')
+                    ->isRequired()
+                    ->scalarPrototype()
+                ->end()
+            ->end();
+
+        return $tree;
+    }
+}

--- a/tests/Fixtures/ConfigurationBundle/DependencyInjection/ConfigurationExtension.php
+++ b/tests/Fixtures/ConfigurationBundle/DependencyInjection/ConfigurationExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Nyholm\BundleTest\Tests\Fixtures\ConfigurationBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+final class ConfigurationExtension extends ConfigurableExtension
+{
+    protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
+    {
+        $container->setParameter('app.foo', $mergedConfig['foo']);
+        $container->setParameter('app.bar', $mergedConfig['bar']);
+    }
+}

--- a/tests/Fixtures/Resources/ConfigurationBundle/config.php
+++ b/tests/Fixtures/Resources/ConfigurationBundle/config.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return function (ContainerConfigurator $container) {
+    $container->extension('configuration', [
+        'foo' => 'val1',
+        'bar' => ['val2', 'val3']
+    ]);
+};

--- a/tests/Fixtures/Resources/ConfigurationBundle/config.xml
+++ b/tests/Fixtures/Resources/ConfigurationBundle/config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:configuration="http://example.org/schema/dic/configuration"
+           xsi:schemaLocation="http://example.org/schema/dic/configuration">
+    <configuration:config foo="val1">
+            <configuration:bar>val2</configuration:bar>
+            <configuration:bar>val3</configuration:bar>
+    </configuration:config>
+</container>

--- a/tests/Fixtures/Resources/ConfigurationBundle/config.yml
+++ b/tests/Fixtures/Resources/ConfigurationBundle/config.yml
@@ -1,0 +1,3 @@
+configuration:
+    foo: val1
+    bar: [val2, val3]

--- a/tests/Functional/BundleConfigurationTest.php
+++ b/tests/Functional/BundleConfigurationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Nyholm\BundleTest\Tests\Functional;
+
+use Nyholm\BundleTest\BaseBundleTestCase;
+use Nyholm\BundleTest\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+final class BundleConfigurationTest extends BaseBundleTestCase
+{
+    protected function getBundleClass()
+    {
+        return ConfigurationBundle::class;
+    }
+
+    public function provideBundleWithDifferentConfigurationFormats()
+    {
+        return [
+            [__DIR__.'/../Fixtures/Resources/ConfigurationBundle/config.yml'],
+            [__DIR__.'/../Fixtures/Resources/ConfigurationBundle/config.xml'],
+            [__DIR__.'/../Fixtures/Resources/ConfigurationBundle/config.php'],
+            [function (ContainerBuilder $container) {
+                $container->loadFromExtension('configuration', [
+                    'foo' => 'val1',
+                    'bar' => ['val2', 'val3'],
+                ]);
+            }],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBundleWithDifferentConfigurationFormats
+     *
+     * @param string|callable $config
+     */
+    public function testBundleWithDifferentConfigurationFormats($config)
+    {
+        $kernel = $this->createKernel();
+        $kernel->addConfigFile($config);
+        $this->bootKernel();
+        $this->assertEquals('val1', $kernel->getContainer()->getParameter('app.foo'));
+        $this->assertEquals(['val2', 'val3'], $kernel->getContainer()->getParameter('app.bar'));
+    }
+}


### PR DESCRIPTION
This is a proposition to allow to test configurations with closures:
```php
public function testBundleWithDifferentConfiguration()
    {
        // Create a new Kernel
        $kernel = $this->createKernel();
        
        // Add some configuration
        $kernel->addConfigFile(function(ContainerBuilder $container) {
                $container->loadFromExtension('configuration', [
                    'foo' => 'val1',
                    'bar' => ['val2', 'val3']
                ]);
            });

        // Boot the kernel as normal ...
        $this->bootKernel();
        
        // ... 
    }
```