### PR TITLE
Set router to utf8 is in symfony 5.1

### DIFF
--- a/src/config/parameters.php
+++ b/src/config/parameters.php
@@ -10,3 +10,10 @@ if (\Symfony\Component\HttpKernel\Kernel::VERSION_ID >= 30300 && !class_exists('
         'annotations' => ['cache' => 'none'],
     ]);
 }
+
+// Not setting the router to utf8 is deprecated in symfony 5.1
+if (\Symfony\Component\HttpKernel\Kernel::VERSION_ID >= 50100) {
+    $container->loadFromExtension('framework', [
+        'router' => ['utf8' => true],
+    ]);
+}


### PR DESCRIPTION
Not setting the router to utf8 is deprecated in symfony 5.1.

This now appeared in the tests of https://github.com/async-aws/aws/pull/645.

I added a condition to set it too true in symfony 5.1+ only.
That option only exists since some time in symfony 4.x so it can't be set as default as long as symfony 3.4 is still supported.
I leave it default in symfony 5.0 and below in order to not change the default in existing version.