### PR TITLE
Fix routing in kernel

### DIFF
--- a/src/AppKernel.php
+++ b/src/AppKernel.php
@@ -197,7 +197,8 @@ class AppKernel extends Kernel
     /**
      * @param string|null $routingFile
      */
-    public function setRoutingFile($routingFile) {
+    public function setRoutingFile($routingFile)
+    {
         $this->routingFile = $routingFile;
     }
 }

--- a/src/AppKernel.php
+++ b/src/AppKernel.php
@@ -40,6 +40,11 @@ class AppKernel extends Kernel
     private $compilerPasses = [];
 
     /**
+     * @var string|null
+     */
+    private $routingFile = null;
+
+    /**
      * @param string $cachePrefix
      */
     public function __construct($cachePrefix)
@@ -121,7 +126,7 @@ class AppKernel extends Kernel
         $loader->load(function (ContainerBuilder $container) use ($loader) {
             $container->loadFromExtension('framework', [
                 'router' => [
-                    'resource' => 'kernel:loadRoutes',
+                    'resource' => 'kernel::loadRoutes',
                     'type' => 'service',
                 ],
             ]);
@@ -130,6 +135,20 @@ class AppKernel extends Kernel
             foreach ($this->configFiles as $path) {
                 $loader->load($path);
             }
+
+            $kernelClass = false !== strpos(static::class, "@anonymous\0") ? parent::class : static::class;
+
+            if (!$container->hasDefinition('kernel')) {
+                $container->register('kernel', $kernelClass)
+                    ->addTag('controller.service_arguments')
+                    ->setAutoconfigured(true)
+                    ->setSynthetic(true)
+                    ->setPublic(true)
+                ;
+            }
+
+            $kernelDefinition = $container->getDefinition('kernel');
+            $kernelDefinition->addTag('routing.route_loader');
 
             $container->addObjectResource($this);
         });
@@ -143,7 +162,12 @@ class AppKernel extends Kernel
     public function loadRoutes(LoaderInterface $loader)
     {
         $routes = new RouteCollectionBuilder($loader);
-        $routes->import(__DIR__.'/config/routing.yml');
+
+        if ($this->routingFile) {
+            $routes->import($this->routingFile);
+        } else {
+            $routes->import(__DIR__.'/config/routing.yml');
+        }
 
         return $routes->build();
     }
@@ -168,5 +192,12 @@ class AppKernel extends Kernel
     public function addCompilerPasses(array $compilerPasses)
     {
         $this->compilerPasses = $compilerPasses;
+    }
+
+    /**
+     * @param string|null $routingFile
+     */
+    public function setRoutingFile($routingFile) {
+        $this->routingFile = $routingFile;
     }
 }

--- a/src/BaseBundleTestCase.php
+++ b/src/BaseBundleTestCase.php
@@ -73,7 +73,7 @@ abstract class BaseBundleTestCase extends TestCase
         $this->kernel = new $class(uniqid('cache'));
         $this->kernel->addBundle($this->getBundleClass());
         $this->kernel->addCompilerPasses($this->compilerPasses);
-        $this->kernel->setRoutingFile($this->routingFile)
+        $this->kernel->setRoutingFile($this->routingFile);
 
         return $this->kernel;
     }

--- a/src/BaseBundleTestCase.php
+++ b/src/BaseBundleTestCase.php
@@ -98,9 +98,6 @@ abstract class BaseBundleTestCase extends TestCase
         }
     }
 
-    /**
-     * @param CompilerPassInterface $compilerPass
-     */
     protected function addCompilerPass(CompilerPassInterface $compilerPass)
     {
         $this->compilerPasses[] = $compilerPass;
@@ -109,7 +106,8 @@ abstract class BaseBundleTestCase extends TestCase
     /**
      * @param string|null $routingFile
      */
-    public function setRoutingFile($routingFile) {
+    public function setRoutingFile($routingFile)
+    {
         $this->routingFile = $routingFile;
     }
 }

--- a/src/BaseBundleTestCase.php
+++ b/src/BaseBundleTestCase.php
@@ -28,6 +28,11 @@ abstract class BaseBundleTestCase extends TestCase
     abstract protected function getBundleClass();
 
     /**
+     * @var string|null
+     */
+    private $routingFile = null;
+
+    /**
      * Boots the Kernel for this test.
      *
      * @param array $options
@@ -68,6 +73,7 @@ abstract class BaseBundleTestCase extends TestCase
         $this->kernel = new $class(uniqid('cache'));
         $this->kernel->addBundle($this->getBundleClass());
         $this->kernel->addCompilerPasses($this->compilerPasses);
+        $this->kernel->setRoutingFile($this->routingFile)
 
         return $this->kernel;
     }
@@ -98,5 +104,12 @@ abstract class BaseBundleTestCase extends TestCase
     protected function addCompilerPass(CompilerPassInterface $compilerPass)
     {
         $this->compilerPasses[] = $compilerPass;
+    }
+
+    /**
+     * @param string|null $routingFile
+     */
+    public function setRoutingFile($routingFile) {
+        $this->routingFile = $routingFile;
     }
 }


### PR DESCRIPTION
I just found the solution by registering the kernel as a service like in the [`MicroKernelTrait.php`](https://github.com/symfony/symfony/blob/15d76e1911c6e5faf3f1ea66a5d6e200c15d9f31/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php#L112-L124)

I also added `setRoutingFile` to set a custom routing file and load routes from the testing bundle.

Fixes: #33 