### PR TITLE
Update name in license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2017 Matthias Noback
+Copyright (c) 2016 Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/Fixtures/Resources/ConfigurationBundle/config.php
+++ b/tests/Fixtures/Resources/ConfigurationBundle/config.php
@@ -5,6 +5,6 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return function (ContainerConfigurator $container) {
     $container->extension('configuration', [
         'foo' => 'val1',
-        'bar' => ['val2', 'val3']
+        'bar' => ['val2', 'val3'],
     ]);
 };


### PR DESCRIPTION
The license file was added (without a PR) in this commit: https://github.com/SymfonyTest/symfony-bundle-test/commit/f211eacc9706ca8428c985e84e4d01c768dd0d18

I guess we synced it up with the other packages in this github organization. However, the organization was created by merging two packages from Noback and one from Nyholm. 

This PR will correct the year and name in the license file. 