### PR TITLE
Use more likely Symfony requirements

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,7 +91,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest, windows-latest ]
         php: [ '7.4', '8.0' ]
-        symfony: ['4.4', '5.3']
+        symfony: ['^4.4', '^5.3']
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Having only `4.4` will require `4.4.0` and not `^4.4` as one would expect (and probably have in composer.json)