### PR TITLE
Rename custom methods and properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class BundleInitializationTest extends KernelTestCase
          * @var TestKernel $kernel
          */
         $kernel = parent::createKernel($options);
-        $kernel->addBundle(AcmeFooBundle::class);
+        $kernel->addTestBundle(AcmeFooBundle::class);
         $kernel->handleOptions($options);
 
         return $kernel;
@@ -59,7 +59,7 @@ class BundleInitializationTest extends KernelTestCase
         // Or for FrameworkBundle@^5.3.6 to access private services without the PublicCompilerPass
         // $container = self::getContainer();
 
-        // Test if you services exists
+        // Test if your services exists
         $this->assertTrue($container->has('acme.foo'));
         $service = $container->get('acme.foo');
         $this->assertInstanceOf(Foo::class, $service);
@@ -67,13 +67,13 @@ class BundleInitializationTest extends KernelTestCase
 
     public function testBundleWithDifferentConfiguration(): void
     {
-        // Boot the kernel as normal ...
+        // Boot the kernel with a config closure, the handleOptions call in createKernel is important for that to work
         $kernel = self::bootKernel(['config' => static function(TestKernel $kernel){
             // Add some other bundles we depend on
-            $kernel->addBundle(OtherBundle::class);
+            $kernel->addTestBundle(OtherBundle::class);
 
             // Add some configuration
-            $kernel->addConfig(__DIR__.'/config.yml');
+            $kernel->addTestConfig(__DIR__.'/config.yml');
         }]);
 
         // ...

--- a/src/TestKernel.php
+++ b/src/TestKernel.php
@@ -23,32 +23,32 @@ class TestKernel extends Kernel
     /**
      * @var string[]
      */
-    private $bundlesToRegister = [];
+    private $testBundle = [];
 
     /**
      * @var string[]|callable[]
      */
-    private $configs = [];
+    private $testConfigs = [];
 
     /**
      * @var string
      */
-    private $cachePrefix;
+    private $testCachePrefix;
 
     /**
      * @var string|null;
      */
-    private $fakedProjectDir;
+    private $testProjectDir;
 
     /**
      * @var CompilerPassInterface[]
      */
-    private $compilerPasses = [];
+    private $testCompilerPasses = [];
 
     /**
      * @var array<int, string>
      */
-    private $routingFiles = [];
+    private $testRoutingFiles = [];
 
     /**
      * {@inheritDoc}
@@ -57,14 +57,14 @@ class TestKernel extends Kernel
     {
         parent::__construct($environment, $debug);
 
-        $this->cachePrefix = uniqid('cache', true);
+        $this->testCachePrefix = uniqid('cache', true);
 
-        $this->addBundle(FrameworkBundle::class);
-        $this->addConfig(__DIR__.'/config/framework.yml');
+        $this->addTestBundle(FrameworkBundle::class);
+        $this->addTestConfig(__DIR__.'/config/framework.yml');
         if (class_exists(ConfigBuilderCacheWarmer::class)) {
-            $this->addConfig(__DIR__.'/config/framework-53.yml');
+            $this->addTestConfig(__DIR__.'/config/framework-53.yml');
         } else {
-            $this->addConfig(__DIR__.'/config/framework-52.yml');
+            $this->addTestConfig(__DIR__.'/config/framework-52.yml');
         }
     }
 
@@ -73,22 +73,22 @@ class TestKernel extends Kernel
      *
      * @param string $bundleClassName
      */
-    public function addBundle($bundleClassName): void
+    public function addTestBundle($bundleClassName): void
     {
-        $this->bundlesToRegister[] = $bundleClassName;
+        $this->testBundle[] = $bundleClassName;
     }
 
     /**
      * @param string|callable $configFile path to a config file or a callable which get the {@see ContainerBuilder} as its first argument
      */
-    public function addConfig($configFile): void
+    public function addTestConfig($configFile): void
     {
-        $this->configs[] = $configFile;
+        $this->testConfigs[] = $configFile;
     }
 
     public function getCacheDir(): string
     {
-        return realpath(sys_get_temp_dir()).'/NyholmBundleTest/'.$this->cachePrefix;
+        return realpath(sys_get_temp_dir()).'/NyholmBundleTest/'.$this->testCachePrefix;
     }
 
     public function getLogDir(): string
@@ -98,26 +98,26 @@ class TestKernel extends Kernel
 
     public function getProjectDir(): string
     {
-        if (null === $this->fakedProjectDir) {
+        if (null === $this->testProjectDir) {
             return realpath(__DIR__.'/../../../../');
         }
 
-        return $this->fakedProjectDir;
+        return $this->testProjectDir;
     }
 
     /**
      * @param string|null $projectDir
      */
-    public function setProjectDir($projectDir): void
+    public function setTestProjectDir($projectDir): void
     {
-        $this->fakedProjectDir = $projectDir;
+        $this->testProjectDir = $projectDir;
     }
 
     public function registerBundles(): iterable
     {
-        $this->bundlesToRegister = array_unique($this->bundlesToRegister);
+        $this->testBundle = array_unique($this->testBundle);
 
-        foreach ($this->bundlesToRegister as $bundle) {
+        foreach ($this->testBundle as $bundle) {
             yield new $bundle();
         }
     }
@@ -129,7 +129,7 @@ class TestKernel extends Kernel
     {
         $container = parent::buildContainer();
 
-        foreach ($this->compilerPasses as $pass) {
+        foreach ($this->testCompilerPasses as $pass) {
             $container->addCompilerPass($pass);
         }
 
@@ -139,17 +139,17 @@ class TestKernel extends Kernel
     /**
      * @param CompilerPassInterface $compilerPasses
      */
-    public function addCompilerPass($compilerPasses): void
+    public function addTestCompilerPass($compilerPasses): void
     {
-        $this->compilerPasses[] = $compilerPasses;
+        $this->testCompilerPasses[] = $compilerPasses;
     }
 
     /**
      * @param string $routingFile
      */
-    public function addRoutingFile($routingFile): void
+    public function addTestRoutingFile($routingFile): void
     {
-        $this->routingFiles[] = $routingFile;
+        $this->testRoutingFiles[] = $routingFile;
     }
 
     public function handleOptions(array $options): void
@@ -165,7 +165,7 @@ class TestKernel extends Kernel
      */
     protected function configureContainer($container, $loader): void
     {
-        foreach ($this->configs as $config) {
+        foreach ($this->testConfigs as $config) {
             $loader->load($config);
         }
     }
@@ -175,7 +175,7 @@ class TestKernel extends Kernel
      */
     protected function configureRoutes($routes): void
     {
-        foreach ($this->routingFiles as $routingFile) {
+        foreach ($this->testRoutingFiles as $routingFile) {
             $routes->import($routingFile);
         }
     }

--- a/tests/Functional/BundleConfigurationTest.php
+++ b/tests/Functional/BundleConfigurationTest.php
@@ -24,7 +24,7 @@ final class BundleConfigurationTest extends KernelTestCase
          * @var TestKernel $kernel
          */
         $kernel = parent::createKernel($options);
-        $kernel->addBundle(ConfigurationBundle::class);
+        $kernel->addTestBundle(ConfigurationBundle::class);
         $kernel->handleOptions($options);
 
         return $kernel;
@@ -53,7 +53,7 @@ final class BundleConfigurationTest extends KernelTestCase
     public function testBundleWithDifferentConfigurationFormats($config): void
     {
         $kernel = self::bootKernel(['config' => function (TestKernel $kernel) use ($config) {
-            $kernel->addConfig($config);
+            $kernel->addTestConfig($config);
         }]);
 
         $container = $kernel->getContainer();

--- a/tests/Functional/BundleInitializationTest.php
+++ b/tests/Functional/BundleInitializationTest.php
@@ -23,7 +23,7 @@ class BundleInitializationTest extends KernelTestCase
          * @var TestKernel $kernel
          */
         $kernel = parent::createKernel($options);
-        $kernel->addBundle(FrameworkBundle::class);
+        $kernel->addTestBundle(FrameworkBundle::class);
 
         return $kernel;
     }

--- a/tests/Functional/BundleRoutingTest.php
+++ b/tests/Functional/BundleRoutingTest.php
@@ -29,7 +29,7 @@ class BundleRoutingTest extends KernelTestCase
     {
         $kernel = self::bootKernel([
             'config' => static function (TestKernel $kernel) {
-                $kernel->addRoutingFile(__DIR__.'/../Fixtures/Resources/Routing/routes.yml');
+                $kernel->addTestRoutingFile(__DIR__.'/../Fixtures/Resources/Routing/routes.yml');
             },
         ]);
 


### PR DESCRIPTION
As mentioned in #56 the propose to rename properties and methods.
This change will make it more clear that all methods (in use as public api) and properties (for maintaining) is for testing purposes.