### PR TITLE
Add branch alias to enable installing the package using `^2.0@dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
             "Nyholm\\BundleTest\\Tests\\": "tests/"
         }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"


### PR DESCRIPTION
Alternatively, consider renaming the master branch to just `2.0`.