### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [ pull_request ]
 jobs:
   tests:
     name: PHPUnit PHP ${{ matrix.php }} ${{ matrix.dependency }} (Symfony ${{ matrix.symfony }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php:
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -76,10 +76,10 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,11 +4,11 @@ name: Static analysis
 jobs:
   phpstan:
     name: PHPStan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -18,23 +18,23 @@ jobs:
           tools: phpstan:1.2.0, cs2pr
 
       - name: Download dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: PHPStan
         run: phpstan analyze --no-progress --error-format=checkstyle | cs2pr
 
   php-cs-fixer:
     name: PHP-CS-Fixer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.2
           coverage: none
           tools: php-cs-fixer:3, cs2pr
 
@@ -43,10 +43,10 @@ jobs:
 
   psalm:
     name: Psalm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -56,25 +56,25 @@ jobs:
           tools: vimeo/psalm:4.8.1
 
       - name: Download dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Psalm
         run: psalm --no-progress --output-format=github
 
   composer-normalize:
     name: Composer Normalize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.2
           coverage: none
           tools: composer-normalize
-
-      - name: Checkout code
-        uses: actions/checkout@v2
 
       - name: Normalize
         run: composer-normalize --dry-run

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ jobs:
         symfony: ['4.4.*', '5.3.*', '5.4.*', '6.0.*', '6.1.*']
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
@@ -117,7 +117,7 @@ jobs:
       - name: Download dependencies
         env:
           SYMFONY_REQUIRE: ${{ matrix.symfony }}
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Run test suite on PHP ${{ matrix.php }} and Symfony ${{ matrix.symfony }}
         run: ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0 || ^8.1",
+        "php": "^7.2 || ^8.0",
         "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
         "symfony/filesystem": "^4.4 || ^5.3 || ^6.0",
         "symfony/framework-bundle": "^4.4 || ^5.3 || ^6.0",

--- a/src/TestKernel.php
+++ b/src/TestKernel.php
@@ -58,9 +58,6 @@ class TestKernel extends Kernel
      */
     private $clearCache = true;
 
-    /**
-     * {@inheritDoc}
-     */
     public function __construct(string $environment, bool $debug)
     {
         parent::__construct($environment, $debug);
@@ -130,9 +127,6 @@ class TestKernel extends Kernel
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function buildContainer(): ContainerBuilder
     {
         $container = parent::buildContainer();


### PR DESCRIPTION
This PR adjusted following:
- uses `ubuntu-22.04` as latest runner image
- uses `actions/checkout@v4` to prevent deprecations
- uses `actions/cache@v3` to prevent deprecations
- uses `ramsey/composer-install@v2` to prevent deprecations
- uses PHP 8.2 for `composer-normalize` to match PHP version requirements
- replaces [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) `set-ouput` with `$GITHUB_OUTPUT`
- applies recommendation from `composer-normalize`
- applies CS fixes