### PR TITLE
Fix injection of undefined annotations.cache parameter

### DIFF
--- a/src/config/parameters.php
+++ b/src/config/parameters.php
@@ -5,7 +5,7 @@ if (!class_exists('Doctrine\Common\Annotations\Annotation')) {
     $container->loadFromExtension('framework', [
         'annotations' => ['enabled' => false],
     ]);
-} else {
+} elseif (method_exists('Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension', 'registerAnnotationsConfiguration')) {
     $container->loadFromExtension('framework', [
         'annotations' => ['cache' => 'none'],
     ]);


### PR DESCRIPTION
This parameter has been removed in https://github.com/symfony/symfony/pull/51050